### PR TITLE
MAPREDUCE-7445. ShuffleSchedulerImpl causes ArithmeticException due to improper detailsInterval value checking -168

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/ShuffleSchedulerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/ShuffleSchedulerImpl.java
@@ -344,6 +344,9 @@ public class ShuffleSchedulerImpl<K,V> implements ShuffleScheduler<K,V> {
   private void checkAndInformMRAppMaster(
       int failures, TaskAttemptID mapId, boolean readError,
       boolean connectExcpt, boolean hostFailed) {
+    if (maxFetchFailuresBeforeReporting == 0) {
+      throw new IllegalArgumentException("maxFetchFailuresBeforeReporting cannot be zero");
+    }
     if (connectExcpt || (reportReadErrorImmediately && readError)
         || ((failures % maxFetchFailuresBeforeReporting) == 0) || hostFailed) {
       LOG.info("Reporting fetch failure for " + mapId + " to MRAppMaster.");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/ShuffleSchedulerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/ShuffleSchedulerImpl.java
@@ -344,14 +344,15 @@ public class ShuffleSchedulerImpl<K,V> implements ShuffleScheduler<K,V> {
   private void checkAndInformMRAppMaster(
       int failures, TaskAttemptID mapId, boolean readError,
       boolean connectExcpt, boolean hostFailed) {
-    if (maxFetchFailuresBeforeReporting == 0) {
-      throw new IllegalArgumentException("maxFetchFailuresBeforeReporting cannot be zero");
-    }
-    if (connectExcpt || (reportReadErrorImmediately && readError)
-        || ((failures % maxFetchFailuresBeforeReporting) == 0) || hostFailed) {
-      LOG.info("Reporting fetch failure for " + mapId + " to MRAppMaster.");
-      status.addFetchFailedMap((org.apache.hadoop.mapred.TaskAttemptID) mapId);
-    }
+      if (maxFetchFailuresBeforeReporting <= 0) {
+        throw new IllegalStateException("maxFetchFailuresBeforeReporting <= 0; Check " + MRJobConfig.SHUFFLE_FETCH_FAILURES
+          + " setting and/or server java heap size");
+      }
+      if (connectExcpt || (reportReadErrorImmediately && readError)
+          || ((failures % maxFetchFailuresBeforeReporting) == 0) || hostFailed) {
+        LOG.info("Reporting fetch failure for " + mapId + " to MRAppMaster.");
+        status.addFetchFailedMap((org.apache.hadoop.mapred.TaskAttemptID) mapId);
+      }
   }
 
   private void checkReducerHealth() {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Add 0 check for `maxFetchFailuresBeforeReporting `, since there is no value checking for parameter `mapreduce.reduce.shuffle.maxfetchfailures`. This may cause improper calculations and crashes the system like division by 0.


### How was this patch tested?
Set `mapreduce.reduce.shuffle.maxfetchfailures`=`0`, `mapreduce.reduce.shuffle.notify.readerror`=`false`.
Then run `mvn surefire:test -Dtest=org.apache.hadoop.mapreduce.task.reduce.TestShuffleScheduler#TestSucceedAndFailedCopyMap`

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
