### PR TITLE
YARN-11541 AsyncDispatcher causes ArithmeticException due to improper detailsInterval value checking -166

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
@@ -185,7 +185,11 @@ public class AsyncDispatcher extends AbstractService implements Dispatcher {
                     YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD,
             YarnConfiguration.
                     DEFAULT_YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD);
-
+    if (detailsInterval <= 0) {
+      throw new IllegalStateException("detailsInterval <= 0; Check " + YarnConfiguration.
+      YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD
+        + " setting and/or server java heap size");
+    }
     ThreadFactory threadFactory = new ThreadFactoryBuilder()
         .setNameFormat("PrintEventDetailsThread #%d")
         .build();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In `AsyncDispatcher.java`, there is no value checking for `detailsInterval` and this variable is directly used in the event handler. When `detailsInterval` is mistakenly set to 0, the code would cause division by 0 and throw ArithmeticException to crash the system.
```java
    public void handle(Event event) {
    . . . 
      if (qSize != 0 && qSize % detailsInterval == 0                 // detailsInterval gets its value from the aforementioned config param 
              && lastEventDetailsQueueSizeLogged != qSize) {
    . . .
```

### How was this patch tested?
run` mvn surefire:test -Dtest=org.apache.hadoop.yarn.event.TestAsyncDispatcher#testDispatcherMetricsHistogram`

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
