### PR TITLE
MAPREDUCE-7445 ShuffleSchedulerImpl causes ArithmeticException due to improper detailsInterval value checking -165

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
@@ -204,6 +204,10 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
                 ZK_DTSM_ZK_SESSION_TIMEOUT_DEFAULT);
         int numRetries =
             conf.getInt(ZK_DTSM_ZK_NUM_RETRIES, ZK_DTSM_ZK_NUM_RETRIES_DEFAULT);
+        if (numRetries <= 0) {
+          throw new IllegalStateException("numRetries <= 0; Check " + ZK_DTSM_ZK_NUM_RETRIES
+            + " setting and/or server java heap size");
+        }
         builder =
             CuratorFrameworkFactory
                 .builder()

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
@@ -185,7 +185,11 @@ public class AsyncDispatcher extends AbstractService implements Dispatcher {
                     YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD,
             YarnConfiguration.
                     DEFAULT_YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD);
-
+    if (detailsInterval <= 0) {
+      throw new IllegalStateException("detailsInterval <= 0; Check " + YarnConfiguration.
+      YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD
+        + " setting and/or server java heap size");
+    }
     ThreadFactory threadFactory = new ThreadFactoryBuilder()
         .setNameFormat("PrintEventDetailsThread #%d")
         .build();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In `ZKDelegationTokenSecretManager.java`, there is no value checking for `numRetries` which is passed directly in `RetryNTimes` constructor. When `numRetries` is mistakenly set to 0, the code would cause division by 0 and throw ArithmeticException to crash the system.

```java
public ZKDelegationTokenSecretManager(Configuration conf) {
    	...
        int numRetries =
            conf.getInt(ZK_DTSM_ZK_NUM_RETRIES, ZK_DTSM_ZK_NUM_RETRIES_DEFAULT);
        builder =
            ...
                .retryPolicy(
                    new RetryNTimes(numRetries, sessionT / numRetries));
        ...
```

### How was this patch tested?
1. set zk-dt-secret-manager.zkNumRetries=0
2. run org.apache.hadoop.security.token.delegation.TestZKDelegationTokenSecretManager.testMultiNodeOperations

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
